### PR TITLE
FIX: delete user when creation of gamehub user failed

### DIFF
--- a/app/user_service/user/views.py
+++ b/app/user_service/user/views.py
@@ -162,6 +162,7 @@ def register(request):
                 'qr_code': f"data:image/png;base64,{qr_code_string}",
             }, status=201)
         except Exception as e:
+            user.delete()
             return Response({'type': 'error', 'message': {'exepction': str(e)}}, status=400)
 
 @api_view(['GET'])


### PR DESCRIPTION
otherwise we have a user, but no gamehub user and email/username is locked out and cannot be used again